### PR TITLE
updated cache for pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,11 +15,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: 3.7
-    - name: Caching
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install -e . --no-cache-dir


### PR DESCRIPTION
The setup-python seems to have a built-in cache. It seems easier to read and maintain using this build-in functionality.